### PR TITLE
Minor typo correction, plus question

### DIFF
--- a/chapters/chapter6.tex
+++ b/chapters/chapter6.tex
@@ -357,9 +357,9 @@ In the second step we used the mass conservation equation to substitute for $\pa
 
 To figure out how the gas moves, we write down the Lagrangian version of the momentum equation:
 \begin{equation}
-\rho \frac{Dv}{Dt} = -\frac{\partial}{\partial r}P - \rho \mathbf{f}_g,
+\rho \frac{Dv}{Dt} = -\frac{\partial}{\partial r}P + \rho \mathbf{f}_g,
 \end{equation}
-where $\mathbf{f}_g$ is the gravitational force per unit mass. For the momentum equation, we take advantage of the fact that the gas is isothermal to write $P=\rho c_s^2$. The gravitational force is $\mathbf{f}_g = G M_r / r^2$. Thus we have
+where $\mathbf{f}_g$ is the gravitational force per unit mass. For the momentum equation, we take advantage of the fact that the gas is isothermal to write $P=\rho c_s^2$. The gravitational force is $\mathbf{f}_g = - G M_r / r^2$. Thus we have
 \begin{equation}
 \frac{Dv}{Dt}= \frac{\partial}{\partial t}v + v\frac{\partial}{\partial r} v= -\frac{c_s^2}{\rho} \frac{\partial}{\partial r}{\rho} - \frac{G M_r}{r^2}.
 \end{equation}

--- a/chapters/chapter6.tex
+++ b/chapters/chapter6.tex
@@ -355,7 +355,7 @@ where $v$ is the radial velocity of the gas. It is useful to write the equations
 \end{eqnarray}
 In the second step we used the mass conservation equation to substitute for $\partial \rho/\partial t$, and in the final step we used the definition of $M_r$ to substitute for $\rho$.
 
-To figure out how the gas moves, we write down the Lagrangean version of the momentum equation:
+To figure out how the gas moves, we write down the Lagrangian version of the momentum equation:
 \begin{equation}
 \rho \frac{Dv}{Dt} = -\frac{\partial}{\partial r}P - \mathbf{f}_g,
 \end{equation}

--- a/chapters/chapter6.tex
+++ b/chapters/chapter6.tex
@@ -359,7 +359,7 @@ To figure out how the gas moves, we write down the Lagrangian version of the mom
 \begin{equation}
 \rho \frac{Dv}{Dt} = -\frac{\partial}{\partial r}P + \rho \mathbf{f}_g,
 \end{equation}
-where $\mathbf{f}_g$ is the gravitational force per unit mass. For the momentum equation, we take advantage of the fact that the gas is isothermal to write $P=\rho c_s^2$. The gravitational force is $\mathbf{f}_g = - G M_r / r^2$. Thus we have
+where $\mathbf{f}_g$ is the gravitational force per unit mass. For the momentum equation, we take advantage of the fact that the gas is isothermal to write $P=\rho c_s^2$. The gravitational force is $\mathbf{f}_g = -G M_r / r^2$. Thus we have
 \begin{equation}
 \frac{Dv}{Dt}= \frac{\partial}{\partial t}v + v\frac{\partial}{\partial r} v= -\frac{c_s^2}{\rho} \frac{\partial}{\partial r}{\rho} - \frac{G M_r}{r^2}.
 \end{equation}

--- a/chapters/chapter6.tex
+++ b/chapters/chapter6.tex
@@ -357,9 +357,9 @@ In the second step we used the mass conservation equation to substitute for $\pa
 
 To figure out how the gas moves, we write down the Lagrangian version of the momentum equation:
 \begin{equation}
-\rho \frac{Dv}{Dt} = -\frac{\partial}{\partial r}P - \mathbf{f}_g,
+\rho \frac{Dv}{Dt} = -\frac{\partial}{\partial r}P - \rho \mathbf{f}_g,
 \end{equation}
-where $\mathbf{f}_g$ is the gravitational force per unit mass. For the momentum equation, we take advantage of the fact that the gas is isothermal to write $P=\rho c_s^2$. The gravitational force is $\mathbf{f}_g = -G M_r / r^2$. Thus we have
+where $\mathbf{f}_g$ is the gravitational force per unit mass. For the momentum equation, we take advantage of the fact that the gas is isothermal to write $P=\rho c_s^2$. The gravitational force is $\mathbf{f}_g = G M_r / r^2$. Thus we have
 \begin{equation}
 \frac{Dv}{Dt}= \frac{\partial}{\partial t}v + v\frac{\partial}{\partial r} v= -\frac{c_s^2}{\rho} \frac{\partial}{\partial r}{\rho} - \frac{G M_r}{r^2}.
 \end{equation}


### PR DESCRIPTION
I think in eqn 6.86, `f_g` should have a `\rho` out in front.

Also, the definition of `f_g` should either not include a negative or the sign should be flipped from 6.86 -> 6.87

<img width="394" alt="image" src="https://user-images.githubusercontent.com/143715/146984634-96407e00-ef8b-4b5d-a350-7462ff19fa2f.png">
