### PR TITLE
Typo: ^2 was outside the brackets, should have a been inside

### DIFF
--- a/chapters/chapter17.tex
+++ b/chapters/chapter17.tex
@@ -119,7 +119,7 @@ where $M$ is the total stellar mass. This is our pressure boundary condition in 
 
 However, spherical accretion is probably not realistic, especially during the later phases of protostellar evolution when accretion rates are small; instead, the accreting material probably falls onto only a small fraction of the stellar surface. In this case we should have the usual vacuum boundary condition on the pressure that applies to main sequence stars, since there will be no ram pressure over most of the stellar surface. We can write down this condition by integrating the equation of hydrostatic balance (equation \ref{eq:hydrobalance}) to obtain 
 \begin{equation}
-P(M) = \frac{G M}{R}^2 \int_{R}^{\infty} \rho \, dr.
+P(M) = \frac{G M}{R^2} \int_{R}^{\infty} \rho \, dr.
 \end{equation}
 If $\kappa_{\rm R}$ changes relatively little past the stellar photosphere, then 
 \begin{equation}


### PR DESCRIPTION
This is just a simple typo; r^2 should be in the denominator (see eqn 17.23, where it is shown correctly)